### PR TITLE
Better syntax for classpath(libs.moko.resources.generator)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        val mokoResourceVersion = libs.versions.mokoResources.get()
-        classpath("dev.icerock.moko:resources-generator:$mokoResourceVersion")
+        classpath(libs.moko.resources.generator)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ moko-resources-compose = { module = "dev.icerock.moko:resources-compose", versio
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"
+moko-resources-generator = { module = "dev.icerock.moko:resources-generator", version.ref = "mokoResources" }
 
 [plugins]
 
@@ -59,4 +60,3 @@ composeCompiler = {id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 sqlDelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
-moko-resources-plugin = { id = "dev.icerock.moko:resources-generator", version.ref = "mokoResources" }


### PR DESCRIPTION
This is more typesafe and nicer-looking